### PR TITLE
feat: Implement OAuth installation store 🔐

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@roughapp/slack-bot",
   "private": true,
   "version": "0.1.0",
-  "packageManager": "pnpm@9.12.0",
+  "packageManager": "pnpm@9.12.1",
   "type": "module",
   "main": "./dist/index.js",
   "author": {
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@slack/bolt": "3.22.0",
-    "@slack/web-api": "7.5.0",
     "@stayradiated/error-boundary": "4.3.0",
     "better-sqlite3": "11.3.0",
     "dotenv": "16.4.5",
@@ -34,7 +33,7 @@
     "@types/better-sqlite3": "7.6.11",
     "tsup": "8.3.0",
     "tsx": "4.19.1",
-    "typescript": "5.6.2",
-    "vitest": "2.1.2"
+    "typescript": "5.6.3",
+    "vitest": "2.1.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@slack/bolt':
         specifier: 3.22.0
         version: 3.22.0
-      '@slack/web-api':
-        specifier: 7.5.0
-        version: 7.5.0
       '@stayradiated/error-boundary':
         specifier: 4.3.0
         version: 4.3.0
@@ -602,10 +599,6 @@ packages:
   '@slack/web-api@6.13.0':
     resolution: {integrity: sha512-dv65crIgdh9ZYHrevLU6XFHTQwTyDmNqEqzuIrV+Vqe/vgiG6w37oex5ePDU1RGm2IJ90H8iOvHFvzdEO/vB+g==}
     engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
-
-  '@slack/web-api@7.5.0':
-    resolution: {integrity: sha512-e1aRwbdnTVz0uQownF8UoyrQFdSs3uXtkPYWCpcb3fW3KuTEGvmEtVzAvj9gqNSlgpWj0o6is7AdptQCELd/rQ==}
-    engines: {node: '>= 18', npm: '>= 8.6.0'}
 
   '@stayradiated/error-boundary@4.3.0':
     resolution: {integrity: sha512-fCTFrdkb+im3yaVheb5xFuLKVuJS2WAP18gwrW3NYwsWc31MMAn5Phtazv6HERnNJIM9DRkYCE0Nmnr9eGXljg==}
@@ -2403,23 +2396,6 @@ snapshots:
       is-stream: 1.1.0
       p-queue: 6.6.2
       p-retry: 4.6.2
-    transitivePeerDependencies:
-      - debug
-
-  '@slack/web-api@7.5.0':
-    dependencies:
-      '@slack/logger': 4.0.0
-      '@slack/types': 2.14.0
-      '@types/node': 20.12.12
-      '@types/retry': 0.12.0
-      axios: 1.7.7
-      eventemitter3: 5.0.1
-      form-data: 4.0.0
-      is-electron: 2.2.2
-      is-stream: 2.0.1
-      p-queue: 6.6.2
-      p-retry: 4.6.2
-      retry: 0.13.1
     transitivePeerDependencies:
       - debug
 

--- a/src/database.ts
+++ b/src/database.ts
@@ -28,9 +28,19 @@ type SlackWorkspaceUser = {
   updatedAt: number
 }
 
+type SlackInstallationId = string & { __brand: 'slackInstallationId' }
+
+type SlackInstallation = {
+  id: SlackInstallationId
+  value: string
+  createdAt: number
+  updatedAt: number
+}
+
 type Database = {
   slackWorkspace: SlackWorkspace
   slackWorkspaceUser: SlackWorkspaceUser
+  slackInstallation: SlackInstallation
 }
 
 type KyselyDb = Kysely<Database>
@@ -49,6 +59,8 @@ export type {
   Database,
   SlackWorkspace,
   SlackWorkspaceUser,
+  SlackInstallationId,
+  SlackInstallation,
   KyselyDb,
 }
 export { db }

--- a/src/env.ts
+++ b/src/env.ts
@@ -4,8 +4,10 @@ import 'dotenv/config'
 
 const $env = z.object({
   DB_PATH: z.string().default('state.db'),
+  SLACK_CLIENT_ID: z.string(),
+  SLACK_CLIENT_SECRET: z.string(),
   SLACK_SIGNING_SECRET: z.string(),
-  SLACK_BOT_TOKEN: z.string(),
+  SLACK_STATE_SECRET: z.string(),
   PORT: z.coerce.number().min(1).default(3000),
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,9 @@ await migrateToLatest(db)
 
 await createClient({
   db,
+  slackClientId: env.SLACK_CLIENT_ID,
+  slackClientSecret: env.SLACK_CLIENT_SECRET,
   slackSigningSecret: env.SLACK_SIGNING_SECRET,
-  slackBotToken: env.SLACK_BOT_TOKEN,
+  slackStateSecret: env.SLACK_STATE_SECRET,
   port: env.PORT,
 })

--- a/src/migrations/2024-10-14-installation-store.ts
+++ b/src/migrations/2024-10-14-installation-store.ts
@@ -1,0 +1,15 @@
+import type { Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable('slack_installation')
+    .addColumn('id', 'text', (col) => col.primaryKey())
+    .addColumn('value', 'text', (col) => col.notNull())
+    .addColumn('created_at', 'integer', (col) => col.notNull())
+    .addColumn('updated_at', 'integer', (col) => col.notNull())
+    .execute()
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable('slack_installation').execute()
+}

--- a/src/slack/installation-store.ts
+++ b/src/slack/installation-store.ts
@@ -1,0 +1,99 @@
+import type {
+  Installation,
+  InstallationQuery,
+  InstallationStore,
+} from '@slack/bolt'
+import { errorBoundary } from '@stayradiated/error-boundary'
+
+import type { KyselyDb } from '#src/database.js'
+import type { SlackInstallationId } from '#src/database.js'
+
+const getInstallationId = (
+  installation: Installation | InstallationQuery<boolean>,
+): SlackInstallationId => {
+  let installationId: string
+
+  if (installation.isEnterpriseInstall) {
+    if ('enterpriseId' in installation && installation.enterpriseId) {
+      installationId = installation.enterpriseId
+    } else if ('enterprise' in installation && installation.enterprise) {
+      installationId = installation.enterprise.id
+    } else {
+      throw new Error(
+        'Could not determine installation ID for enterprise installation',
+      )
+    }
+  } else {
+    if ('teamId' in installation && installation.teamId) {
+      installationId = installation.teamId
+    } else if ('team' in installation && installation.team) {
+      installationId = installation.team.id
+    } else {
+      throw new Error(
+        'Could not determine installation ID for single team installation',
+      )
+    }
+  }
+
+  return installationId as SlackInstallationId
+}
+
+const createInstallationStore = (db: KyselyDb): InstallationStore => {
+  return {
+    storeInstallation: async (installation) => {
+      const installationId = getInstallationId(installation)
+
+      const result = await errorBoundary(() =>
+        db
+          .insertInto('slackInstallation')
+          .values({
+            id: installationId,
+            value: JSON.stringify(installation),
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          })
+          .execute(),
+      )
+      if (result instanceof Error) {
+        console.error(result)
+        throw new Error('Failed saving installation data to installationStore')
+      }
+    },
+    fetchInstallation: async (installQuery) => {
+      const installationId = getInstallationId(installQuery)
+
+      const installation = await errorBoundary(async () => {
+        const row = await db
+          .selectFrom('slackInstallation')
+          .select('value')
+          .where('id', '=', installationId)
+          .executeTakeFirstOrThrow()
+
+        return JSON.parse(row.value) as Installation
+      })
+      if (installation instanceof Error) {
+        console.error(installation)
+        throw new Error('Failed fetching installation')
+      }
+
+      return installation
+    },
+    deleteInstallation: async (installQuery) => {
+      const installationId = getInstallationId(installQuery)
+
+      const result = await errorBoundary(() =>
+        db
+          .deleteFrom('slackInstallation')
+          .where('id', '=', installationId)
+          .execute(),
+      )
+
+      if (result instanceof Error) {
+        console.error(result)
+        throw new Error('Failed to delete installation')
+      }
+    },
+  }
+}
+
+export { createInstallationStore }


### PR DESCRIPTION
- Updated package.json with latest dependencies and removed @slack/web-api
- Added SlackInstallation type and related types to database.ts
- Updated env.ts with new environment variables for Slack OAuth
- Modified index.ts to use new OAuth configuration
- Created new migration for slack_installation table
- Refactored client.ts to use OAuth installation store
- Implemented installation-store.ts for managing Slack installations

This commit introduces OAuth support for the Slack bot, allowing for more secure and flexible installations. The changes include setting up an installation store to persist OAuth tokens, updating the Slack client configuration, and adjusting the environment variables to support OAuth flow.