### PR TITLE
feat: Add tests for installation store and improve DB handling 🧪

### DIFF
--- a/.github/workflows/standard.workflow.yml
+++ b/.github/workflows/standard.workflow.yml
@@ -25,13 +25,12 @@ jobs:
         name: Install Node.js
         uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
         with:
-          node-version: 22
+          node-version-file: package.json
 
       - # https://github.com/pnpm/action-setup
         name: Install pnpm
         uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
         with:
-          version: 9
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/standard.workflow.yml
+++ b/.github/workflows/standard.workflow.yml
@@ -1,0 +1,61 @@
+name: Standard
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  main:
+    name: Standard
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+
+    steps:
+      - # https://github.com/actions/checkout
+        name: Checkout
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
+      - # https://github.com/actions/setup-node
+        name: Install Node.js
+        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
+        with:
+          node-version: 22
+
+      - # https://github.com/pnpm/action-setup
+        name: Install pnpm
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+        with:
+          version: 9
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - # https://github.com/actions/cache
+        uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4.1.1
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Biome
+        run: pnpm run tidy:check
+
+      - name: Typescript
+        run: pnpm run tsc
+
+      - name: Vitest
+        run: pnpm run test

--- a/biome.json
+++ b/biome.json
@@ -1,27 +1,27 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.8.1/schema.json",
-	"formatter": {
-		"enabled": true,
-		"formatWithErrors": false,
-		"indentStyle": "space",
-		"indentWidth": 2,
-		"lineEnding": "lf",
-		"lineWidth": 80,
-		"attributePosition": "auto"
-	},
-	"organizeImports": { "enabled": true },
-	"linter": { "enabled": true, "rules": { "recommended": true } },
-	"javascript": {
-		"formatter": {
-			"jsxQuoteStyle": "double",
-			"quoteProperties": "asNeeded",
-			"trailingCommas": "all",
-			"semicolons": "asNeeded",
-			"arrowParentheses": "always",
-			"bracketSpacing": true,
-			"bracketSameLine": false,
-			"quoteStyle": "single",
-			"attributePosition": "auto"
-		}
-	}
+  "$schema": "https://biomejs.dev/schemas/1.8.1/schema.json",
+  "formatter": {
+    "enabled": true,
+    "formatWithErrors": false,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 80,
+    "attributePosition": "auto"
+  },
+  "organizeImports": { "enabled": true },
+  "linter": { "enabled": true, "rules": { "recommended": true } },
+  "javascript": {
+    "formatter": {
+      "jsxQuoteStyle": "double",
+      "quoteProperties": "asNeeded",
+      "trailingCommas": "all",
+      "semicolons": "asNeeded",
+      "arrowParentheses": "always",
+      "bracketSpacing": true,
+      "bracketSameLine": false,
+      "quoteStyle": "single",
+      "attributePosition": "auto"
+    }
+  }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,54 +1,49 @@
 {
-    "display_information": {
-        "name": "Rough"
+  "display_information": {
+    "name": "Rough"
+  },
+  "features": {
+    "bot_user": {
+      "display_name": "Rough",
+      "always_online": false
     },
-    "features": {
-        "bot_user": {
-            "display_name": "Rough",
-            "always_online": false
-        },
-        "shortcuts": [
-            {
-                "name": "Capture Insight",
-                "type": "message",
-                "callback_id": "create_insight",
-                "description": "Creates an Insight in Rough.app"
-            }
-        ],
-        "slash_commands": [
-            {
-                "command": "/rough-connect",
-                "url": "https://slack.rough.app/slack/events",
-                "description": "Connect this Slack workspace to Rough",
-                "usage_hint": "[api token]",
-                "should_escape": false
-            },
-            {
-                "command": "/rough-identify",
-                "url": "https://slack.rough.app/slack/events",
-                "description": "Link your Slack account with Rough",
-                "should_escape": false
-            }
-        ]
-    },
-    "oauth_config": {
-        "scopes": {
-            "bot": [
-                "commands",
-                "reactions:write",
-                "users:read",
-                "team:read"
-            ]
-        }
-    },
-    "settings": {
-        "interactivity": {
-            "is_enabled": true,
-            "request_url": "https://slack.rough.app/slack/events",
-            "message_menu_options_url": "https://slack.rough.app/slack/events"
-        },
-        "org_deploy_enabled": false,
-        "socket_mode_enabled": false,
-        "token_rotation_enabled": false
+    "shortcuts": [
+      {
+        "name": "Capture Insight",
+        "type": "message",
+        "callback_id": "create_insight",
+        "description": "Creates an Insight in Rough.app"
+      }
+    ],
+    "slash_commands": [
+      {
+        "command": "/rough-connect",
+        "url": "https://slack.rough.app/slack/events",
+        "description": "Connect this Slack workspace to Rough",
+        "usage_hint": "[api token]",
+        "should_escape": false
+      },
+      {
+        "command": "/rough-identify",
+        "url": "https://slack.rough.app/slack/events",
+        "description": "Link your Slack account with Rough",
+        "should_escape": false
+      }
+    ]
+  },
+  "oauth_config": {
+    "scopes": {
+      "bot": ["commands", "reactions:write", "users:read", "team:read"]
     }
+  },
+  "settings": {
+    "interactivity": {
+      "is_enabled": true,
+      "request_url": "https://slack.rough.app/slack/events",
+      "message_menu_options_url": "https://slack.rough.app/slack/events"
+    },
+    "org_deploy_enabled": false,
+    "socket_mode_enabled": false,
+    "token_rotation_enabled": false
+  }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -32,6 +32,7 @@
     ]
   },
   "oauth_config": {
+    "redirect_urls": ["https://slack.rough.app/slack/oauth_redirect"],
     "scopes": {
       "bot": ["commands", "reactions:write", "users:read", "team:read"]
     }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   },
   "scripts": {
     "test": "vitest",
-    "tidy": "biome check --write --unsafe ./src",
-    "tidy:check": "biome check ./src",
+    "tidy": "biome check --write --unsafe",
+    "tidy:check": "biome check",
     "build": "tsup",
     "watch": "tsx --watch ./src/index.ts",
     "start": "tsx --env-file=.env ./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "test": "vitest",
     "tidy": "biome check --write --unsafe ./src",
+    "tidy:check": "biome check ./src",
     "build": "tsup",
     "watch": "tsx --watch ./src/index.ts",
     "start": "tsx --env-file=.env ./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "#src/*": "./dist/*"
   },
   "scripts": {
-    "test": "vitest --watch=false",
+    "test": "vitest",
     "tidy": "biome check --write --unsafe ./src",
     "build": "tsup",
     "watch": "tsx --watch ./src/index.ts",
@@ -26,6 +26,7 @@
     "better-sqlite3": "11.3.0",
     "dotenv": "16.4.5",
     "kysely": "0.27.4",
+    "memoize": "10.0.0",
     "zod": "3.23.8"
   },
   "devDependencies": {
@@ -34,6 +35,7 @@
     "tsup": "8.3.0",
     "tsx": "4.19.1",
     "typescript": "5.6.3",
+    "vite-tsconfig-paths": "5.0.1",
     "vitest": "2.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
     "typescript": "5.6.3",
     "vite-tsconfig-paths": "5.0.1",
     "vitest": "2.1.3"
+  },
+  "engines": {
+    "node": "^22.9.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       kysely:
         specifier: 0.27.4
         version: 0.27.4
+      memoize:
+        specifier: 10.0.0
+        version: 10.0.0
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -35,16 +38,19 @@ importers:
         version: 7.6.11
       tsup:
         specifier: 8.3.0
-        version: 8.3.0(postcss@8.4.38)(tsx@4.19.1)(typescript@5.6.2)
+        version: 8.3.0(postcss@8.4.38)(tsx@4.19.1)(typescript@5.6.3)
       tsx:
         specifier: 4.19.1
         version: 4.19.1
       typescript:
-        specifier: 5.6.2
-        version: 5.6.2
+        specifier: 5.6.3
+        version: 5.6.3
+      vite-tsconfig-paths:
+        specifier: 5.0.1
+        version: 5.0.1(typescript@5.6.3)(vite@5.2.11(@types/node@20.12.12)(terser@5.31.0))
       vitest:
-        specifier: 2.1.2
-        version: 2.1.2(@types/node@20.12.12)(terser@5.31.0)
+        specifier: 2.1.3
+        version: 2.1.3(@types/node@20.12.12)(terser@5.31.0)
 
 packages:
 
@@ -412,19 +418,9 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@rollup/rollup-android-arm-eabi@4.18.0':
-    resolution: {integrity: sha512-Tya6xypR10giZV1XzxmH5wr25VcZSncG0pZIjfePT0OVBvqNEurzValetGNarVrGiq66EBVAFn15iYX4w6FKgQ==}
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm-eabi@4.24.0':
     resolution: {integrity: sha512-Q6HJd7Y6xdB48x8ZNVDOqsbh2uByBhgK8PiQgPhwkIw/HC/YX5Ghq2mQY5sRMZWHb3VsFkWooUVOZHKr7DmDIA==}
     cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.18.0':
-    resolution: {integrity: sha512-avCea0RAP03lTsDhEyfy+hpfr85KfyTctMADqHVhLAF3MlIkq83CP8UfAHUssgXTYd+6er6PaAhx/QGv4L1EiA==}
-    cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.24.0':
@@ -432,19 +428,9 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.18.0':
-    resolution: {integrity: sha512-IWfdwU7KDSm07Ty0PuA/W2JYoZ4iTj3TUQjkVsO/6U+4I1jN5lcR71ZEvRh52sDOERdnNhhHU57UITXz5jC1/w==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-arm64@4.24.0':
     resolution: {integrity: sha512-bIv+X9xeSs1XCk6DVvkO+S/z8/2AMt/2lMqdQbMrmVpgFvXlmde9mLcbQpztXm1tajC3raFDqegsH18HQPMYtA==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.18.0':
-    resolution: {integrity: sha512-n2LMsUz7Ynu7DoQrSQkBf8iNrjOGyPLrdSg802vk6XT3FtsgX6JbE8IHRvposskFm9SNxzkLYGSq9QdpLYpRNA==}
-    cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.24.0':
@@ -452,18 +438,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.18.0':
-    resolution: {integrity: sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==}
-    cpu: [arm]
-    os: [linux]
-
   '@rollup/rollup-linux-arm-gnueabihf@4.24.0':
     resolution: {integrity: sha512-0KXvIJQMOImLCVCz9uvvdPgfyWo93aHHp8ui3FrtOP57svqrF/roSSR5pjqL2hcMp0ljeGlU4q9o/rQaAQ3AYA==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.18.0':
-    resolution: {integrity: sha512-l3m9ewPgjQSXrUMHg93vt0hYCGnrMOcUpTz6FLtbwljo2HluS4zTXFy2571YQbisTnfTKPZ01u/ukJdQTLGh9A==}
     cpu: [arm]
     os: [linux]
 
@@ -472,18 +448,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.18.0':
-    resolution: {integrity: sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==}
-    cpu: [arm64]
-    os: [linux]
-
   '@rollup/rollup-linux-arm64-gnu@4.24.0':
     resolution: {integrity: sha512-i0xTLXjqap2eRfulFVlSnM5dEbTVque/3Pi4g2y7cxrs7+a9De42z4XxKLYJ7+OhE3IgxvfQM7vQc43bwTgPwA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-musl@4.18.0':
-    resolution: {integrity: sha512-be6Yx37b24ZwxQ+wOQXXLZqpq4jTckJhtGlWGZs68TgdKXJgw54lUUoFYrg6Zs/kjzAQwEwYbp8JxZVzZLRepQ==}
     cpu: [arm64]
     os: [linux]
 
@@ -492,19 +458,9 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.18.0':
-    resolution: {integrity: sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==}
-    cpu: [ppc64]
-    os: [linux]
-
   '@rollup/rollup-linux-powerpc64le-gnu@4.24.0':
     resolution: {integrity: sha512-2XFFPJ2XMEiF5Zi2EBf4h73oR1V/lycirxZxHZNc93SqDN/IWhYYSYj8I9381ikUFXZrz2v7r2tOVk2NBwxrWw==}
     cpu: [ppc64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.18.0':
-    resolution: {integrity: sha512-ROCM7i+m1NfdrsmvwSzoxp9HFtmKGHEqu5NNDiZWQtXLA8S5HBCkVvKAxJ8U+CVctHwV2Gb5VUaK7UAkzhDjlg==}
-    cpu: [riscv64]
     os: [linux]
 
   '@rollup/rollup-linux-riscv64-gnu@4.24.0':
@@ -512,28 +468,13 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.18.0':
-    resolution: {integrity: sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==}
-    cpu: [s390x]
-    os: [linux]
-
   '@rollup/rollup-linux-s390x-gnu@4.24.0':
     resolution: {integrity: sha512-mjBaoo4ocxJppTorZVKWFpy1bfFj9FeCMJqzlMQGjpNPY9JwQi7OuS1axzNIk0nMX6jSgy6ZURDZ2w0QW6D56g==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.18.0':
-    resolution: {integrity: sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==}
-    cpu: [x64]
-    os: [linux]
-
   '@rollup/rollup-linux-x64-gnu@4.24.0':
     resolution: {integrity: sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-musl@4.18.0':
-    resolution: {integrity: sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==}
     cpu: [x64]
     os: [linux]
 
@@ -542,29 +483,14 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.18.0':
-    resolution: {integrity: sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-arm64-msvc@4.24.0':
     resolution: {integrity: sha512-VXBrnPWgBpVDCVY6XF3LEW0pOU51KbaHhccHw6AS6vBWIC60eqsH19DAeeObl+g8nKAz04QFdl/Cefta0xQtUQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.18.0':
-    resolution: {integrity: sha512-Txjh+IxBPbkUB9+SXZMpv+b/vnTEtFyfWZgJ6iyCmt2tdx0OF5WhFowLmnh8ENGNpfUlUZkdI//4IEmhwPieNg==}
-    cpu: [ia32]
-    os: [win32]
-
   '@rollup/rollup-win32-ia32-msvc@4.24.0':
     resolution: {integrity: sha512-xrNcGDU0OxVcPTH/8n/ShH4UevZxKIO6HJFK0e15XItZP2UcaiLFd5kiX7hJnqCbSztUF8Qot+JWBC/QXRPYWQ==}
     cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.18.0':
-    resolution: {integrity: sha512-UOo5FdvOL0+eIVTgS4tIdbW+TtnBLWg1YBCcU2KWM7nuNwRz9bksDX1bekJJCpu25N1DVWaCwnT39dVQxzqS8g==}
-    cpu: [x64]
     os: [win32]
 
   '@rollup/rollup-win32-x64-msvc@4.24.0':
@@ -611,9 +537,6 @@ packages:
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
-
-  '@types/estree@1.0.5':
-    resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -663,13 +586,13 @@ packages:
   '@types/ws@7.4.7':
     resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
 
-  '@vitest/expect@2.1.2':
-    resolution: {integrity: sha512-FEgtlN8mIUSEAAnlvn7mP8vzaWhEaAEvhSXCqrsijM7K6QqjB11qoRZYEd4AKSCDz8p0/+yH5LzhZ47qt+EyPg==}
+  '@vitest/expect@2.1.3':
+    resolution: {integrity: sha512-SNBoPubeCJhZ48agjXruCI57DvxcsivVDdWz+SSsmjTT4QN/DfHk3zB/xKsJqMs26bLZ/pNRLnCf0j679i0uWQ==}
 
-  '@vitest/mocker@2.1.2':
-    resolution: {integrity: sha512-ExElkCGMS13JAJy+812fw1aCv2QO/LBK6CyO4WOPAzLTmve50gydOlWhgdBJPx2ztbADUq3JVI0C5U+bShaeEA==}
+  '@vitest/mocker@2.1.3':
+    resolution: {integrity: sha512-eSpdY/eJDuOvuTA3ASzCjdithHa+GIF1L4PqtEELl6Qa3XafdMLBpBlZCIUCX2J+Q6sNmjmxtosAG62fK4BlqQ==}
     peerDependencies:
-      '@vitest/spy': 2.1.2
+      '@vitest/spy': 2.1.3
       msw: ^2.3.5
       vite: ^5.0.0
     peerDependenciesMeta:
@@ -678,20 +601,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@2.1.2':
-    resolution: {integrity: sha512-FIoglbHrSUlOJPDGIrh2bjX1sNars5HbxlcsFKCtKzu4+5lpsRhOCVcuzp0fEhAGHkPZRIXVNzPcpSlkoZ3LuA==}
+  '@vitest/pretty-format@2.1.3':
+    resolution: {integrity: sha512-XH1XdtoLZCpqV59KRbPrIhFCOO0hErxrQCMcvnQete3Vibb9UeIOX02uFPfVn3Z9ZXsq78etlfyhnkmIZSzIwQ==}
 
-  '@vitest/runner@2.1.2':
-    resolution: {integrity: sha512-UCsPtvluHO3u7jdoONGjOSil+uON5SSvU9buQh3lP7GgUXHp78guN1wRmZDX4wGK6J10f9NUtP6pO+SFquoMlw==}
+  '@vitest/runner@2.1.3':
+    resolution: {integrity: sha512-JGzpWqmFJ4fq5ZKHtVO3Xuy1iF2rHGV4d/pdzgkYHm1+gOzNZtqjvyiaDGJytRyMU54qkxpNzCx+PErzJ1/JqQ==}
 
-  '@vitest/snapshot@2.1.2':
-    resolution: {integrity: sha512-xtAeNsZ++aRIYIUsek7VHzry/9AcxeULlegBvsdLncLmNCR6tR8SRjn8BbDP4naxtccvzTqZ+L1ltZlRCfBZFA==}
+  '@vitest/snapshot@2.1.3':
+    resolution: {integrity: sha512-qWC2mWc7VAXmjAkEKxrScWHWFyCQx/cmiZtuGqMi+WwqQJ2iURsVY4ZfAK6dVo6K2smKRU6l3BPwqEBvhnpQGg==}
 
-  '@vitest/spy@2.1.2':
-    resolution: {integrity: sha512-GSUi5zoy+abNRJwmFhBDC0yRuVUn8WMlQscvnbbXdKLXX9dE59YbfwXxuJ/mth6eeqIzofU8BB5XDo/Ns/qK2A==}
+  '@vitest/spy@2.1.3':
+    resolution: {integrity: sha512-Nb2UzbcUswzeSP7JksMDaqsI43Sj5+Kry6ry6jQJT4b5gAK+NS9NED6mDb8FlMRCX8m5guaHCDZmqYMMWRy5nQ==}
 
-  '@vitest/utils@2.1.2':
-    resolution: {integrity: sha512-zMO2KdYy6mx56btx9JvAqAZ6EyS3g49krMPPrgOp1yxGZiA93HumGk+bZ5jIZtOg5/VBYl5eBmGRQHqq4FG6uQ==}
+  '@vitest/utils@2.1.3':
+    resolution: {integrity: sha512-xpiVfDSg1RrYT0tX6czgerkpcKFmFOF/gCr30+Mve5V2kewCy4Prn1/NDMSRwaSmT7PRaOF83wu+bEtsY1wrvA==}
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -1138,6 +1061,9 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
+  globrex@0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+
   gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
 
@@ -1370,6 +1296,10 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  memoize@10.0.0:
+    resolution: {integrity: sha512-H6cBLgsi6vMWOcCpvVCdFFnl3kerEXbrYh9q+lY6VXvQSmM6CkmV08VOwT+WE2tzIEqRPFfAq3fm4v/UIW6mSA==}
+    engines: {node: '>=18'}
+
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
 
@@ -1396,6 +1326,10 @@ packages:
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
 
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -1626,11 +1560,6 @@ packages:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
 
-  rollup@4.18.0:
-    resolution: {integrity: sha512-QmJz14PX3rzbJCN1SG4Xe/bAAX2a6NpCP8ab2vfu2GiUr8AQcr2nCV/oEO3yneFarB67zk8ShlIyWb2LGTb3Sg==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-
   rollup@4.24.0:
     resolution: {integrity: sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -1833,6 +1762,16 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  tsconfck@3.1.4:
+    resolution: {integrity: sha512-kdqWFGVJqe+KGYvlSO9NIaWn9jT1Ny4oKVzAJsKii5eoE9snzTJzL4+MMVOMn+fikWGFmKEylcXL710V/kIPJQ==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   tsscmp@1.0.6:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
     engines: {node: '>=0.6.x'}
@@ -1884,8 +1823,8 @@ packages:
     resolution: {integrity: sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==}
     engines: {node: '>= 0.4'}
 
-  typescript@5.6.2:
-    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
+  typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -1910,10 +1849,18 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vite-node@2.1.2:
-    resolution: {integrity: sha512-HPcGNN5g/7I2OtPjLqgOtCRu/qhVvBxTUD3qzitmL0SrG1cWFzxzhMDWussxSbrRYWqnKf8P2jiNhPMSN+ymsQ==}
+  vite-node@2.1.3:
+    resolution: {integrity: sha512-I1JadzO+xYX887S39Do+paRePCKoiDrWRRjp9kkG5he0t7RXNvPAJPCQSJqbGN4uCrFFeS3Kj3sLqY8NMYBEdA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
+
+  vite-tsconfig-paths@5.0.1:
+    resolution: {integrity: sha512-yqwv+LstU7NwPeNqajZzLEBVpUFU6Dugtb2P84FXuvaoYA+/70l9MHE+GYfYAycVyPSDYZ7mjOFuYBRqlEpTig==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
 
   vite@5.2.11:
     resolution: {integrity: sha512-HndV31LWW05i1BLPMUCE1B9E9GFbOu1MbenhS58FuK6owSO5qHm7GiCotrNY1YE5rMeQSFBGmT5ZaLEjFizgiQ==}
@@ -1943,15 +1890,15 @@ packages:
       terser:
         optional: true
 
-  vitest@2.1.2:
-    resolution: {integrity: sha512-veNjLizOMkRrJ6xxb+pvxN6/QAWg95mzcRjtmkepXdN87FNfxAss9RKe2far/G9cQpipfgP2taqg0KiWsquj8A==}
+  vitest@2.1.3:
+    resolution: {integrity: sha512-Zrxbg/WiIvUP2uEzelDNTXmEMJXuzJ1kCpbDvaKByFA9MNeO95V+7r/3ti0qzJzrxdyuUw5VduN7k+D3VmVOSA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 2.1.2
-      '@vitest/ui': 2.1.2
+      '@vitest/browser': 2.1.3
+      '@vitest/ui': 2.1.3
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -2230,97 +2177,49 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.18.0':
-    optional: true
-
   '@rollup/rollup-android-arm-eabi@4.24.0':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.18.0':
     optional: true
 
   '@rollup/rollup-android-arm64@4.24.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.18.0':
-    optional: true
-
   '@rollup/rollup-darwin-arm64@4.24.0':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.18.0':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.24.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.18.0':
-    optional: true
-
   '@rollup/rollup-linux-arm-gnueabihf@4.24.0':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.18.0':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.24.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.18.0':
-    optional: true
-
   '@rollup/rollup-linux-arm64-gnu@4.24.0':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.18.0':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.24.0':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.18.0':
-    optional: true
-
   '@rollup/rollup-linux-powerpc64le-gnu@4.24.0':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-gnu@4.18.0':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.24.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.18.0':
-    optional: true
-
   '@rollup/rollup-linux-s390x-gnu@4.24.0':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.18.0':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.24.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.18.0':
-    optional: true
-
   '@rollup/rollup-linux-x64-musl@4.24.0':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.18.0':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.24.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.18.0':
-    optional: true
-
   '@rollup/rollup-win32-ia32-msvc@4.24.0':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.18.0':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.24.0':
@@ -2414,8 +2313,6 @@ snapshots:
     dependencies:
       '@types/node': 20.12.12
 
-  '@types/estree@1.0.5': {}
-
   '@types/estree@1.0.6': {}
 
   '@types/express-serve-static-core@4.19.6':
@@ -2473,43 +2370,43 @@ snapshots:
     dependencies:
       '@types/node': 20.12.12
 
-  '@vitest/expect@2.1.2':
+  '@vitest/expect@2.1.3':
     dependencies:
-      '@vitest/spy': 2.1.2
-      '@vitest/utils': 2.1.2
+      '@vitest/spy': 2.1.3
+      '@vitest/utils': 2.1.3
       chai: 5.1.1
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.2(@vitest/spy@2.1.2)(vite@5.2.11(@types/node@20.12.12)(terser@5.31.0))':
+  '@vitest/mocker@2.1.3(@vitest/spy@2.1.3)(vite@5.2.11(@types/node@20.12.12)(terser@5.31.0))':
     dependencies:
-      '@vitest/spy': 2.1.2
+      '@vitest/spy': 2.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.11
     optionalDependencies:
       vite: 5.2.11(@types/node@20.12.12)(terser@5.31.0)
 
-  '@vitest/pretty-format@2.1.2':
+  '@vitest/pretty-format@2.1.3':
     dependencies:
       tinyrainbow: 1.2.0
 
-  '@vitest/runner@2.1.2':
+  '@vitest/runner@2.1.3':
     dependencies:
-      '@vitest/utils': 2.1.2
+      '@vitest/utils': 2.1.3
       pathe: 1.1.2
 
-  '@vitest/snapshot@2.1.2':
+  '@vitest/snapshot@2.1.3':
     dependencies:
-      '@vitest/pretty-format': 2.1.2
+      '@vitest/pretty-format': 2.1.3
       magic-string: 0.30.11
       pathe: 1.1.2
 
-  '@vitest/spy@2.1.2':
+  '@vitest/spy@2.1.3':
     dependencies:
       tinyspy: 3.0.0
 
-  '@vitest/utils@2.1.2':
+  '@vitest/utils@2.1.3':
     dependencies:
-      '@vitest/pretty-format': 2.1.2
+      '@vitest/pretty-format': 2.1.3
       loupe: 3.1.1
       tinyrainbow: 1.2.0
 
@@ -2929,7 +2826,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
 
   etag@1.8.1: {}
 
@@ -3097,6 +2994,8 @@ snapshots:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.0.1
+
+  globrex@0.1.2: {}
 
   gopd@1.0.1:
     dependencies:
@@ -3311,6 +3210,10 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  memoize@10.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
   merge-descriptors@1.0.3: {}
 
   merge-stream@2.0.0: {}
@@ -3326,6 +3229,8 @@ snapshots:
   mime@1.6.0: {}
 
   mimic-fn@2.1.0: {}
+
+  mimic-function@5.0.1: {}
 
   mimic-response@3.1.0: {}
 
@@ -3530,28 +3435,6 @@ snapshots:
   resolve-pkg-maps@1.0.0: {}
 
   retry@0.13.1: {}
-
-  rollup@4.18.0:
-    dependencies:
-      '@types/estree': 1.0.5
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.18.0
-      '@rollup/rollup-android-arm64': 4.18.0
-      '@rollup/rollup-darwin-arm64': 4.18.0
-      '@rollup/rollup-darwin-x64': 4.18.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.18.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.18.0
-      '@rollup/rollup-linux-arm64-gnu': 4.18.0
-      '@rollup/rollup-linux-arm64-musl': 4.18.0
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.18.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.18.0
-      '@rollup/rollup-linux-s390x-gnu': 4.18.0
-      '@rollup/rollup-linux-x64-gnu': 4.18.0
-      '@rollup/rollup-linux-x64-musl': 4.18.0
-      '@rollup/rollup-win32-arm64-msvc': 4.18.0
-      '@rollup/rollup-win32-ia32-msvc': 4.18.0
-      '@rollup/rollup-win32-x64-msvc': 4.18.0
-      fsevents: 2.3.3
 
   rollup@4.24.0:
     dependencies:
@@ -3808,9 +3691,13 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  tsconfck@3.1.4(typescript@5.6.3):
+    optionalDependencies:
+      typescript: 5.6.3
+
   tsscmp@1.0.6: {}
 
-  tsup@8.3.0(postcss@8.4.38)(tsx@4.19.1)(typescript@5.6.2):
+  tsup@8.3.0(postcss@8.4.38)(tsx@4.19.1)(typescript@5.6.3):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.23.1)
       cac: 6.7.14
@@ -3830,7 +3717,7 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.4.38
-      typescript: 5.6.2
+      typescript: 5.6.3
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -3885,7 +3772,7 @@ snapshots:
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
 
-  typescript@5.6.2: {}
+  typescript@5.6.3: {}
 
   unbox-primitive@1.0.2:
     dependencies:
@@ -3904,7 +3791,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@2.1.2(@types/node@20.12.12)(terser@5.31.0):
+  vite-node@2.1.3(@types/node@20.12.12)(terser@5.31.0):
     dependencies:
       cac: 6.7.14
       debug: 4.3.6
@@ -3920,25 +3807,36 @@ snapshots:
       - supports-color
       - terser
 
+  vite-tsconfig-paths@5.0.1(typescript@5.6.3)(vite@5.2.11(@types/node@20.12.12)(terser@5.31.0)):
+    dependencies:
+      debug: 4.3.6
+      globrex: 0.1.2
+      tsconfck: 3.1.4(typescript@5.6.3)
+    optionalDependencies:
+      vite: 5.2.11(@types/node@20.12.12)(terser@5.31.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   vite@5.2.11(@types/node@20.12.12)(terser@5.31.0):
     dependencies:
       esbuild: 0.20.2
       postcss: 8.4.38
-      rollup: 4.18.0
+      rollup: 4.24.0
     optionalDependencies:
       '@types/node': 20.12.12
       fsevents: 2.3.3
       terser: 5.31.0
 
-  vitest@2.1.2(@types/node@20.12.12)(terser@5.31.0):
+  vitest@2.1.3(@types/node@20.12.12)(terser@5.31.0):
     dependencies:
-      '@vitest/expect': 2.1.2
-      '@vitest/mocker': 2.1.2(@vitest/spy@2.1.2)(vite@5.2.11(@types/node@20.12.12)(terser@5.31.0))
-      '@vitest/pretty-format': 2.1.2
-      '@vitest/runner': 2.1.2
-      '@vitest/snapshot': 2.1.2
-      '@vitest/spy': 2.1.2
-      '@vitest/utils': 2.1.2
+      '@vitest/expect': 2.1.3
+      '@vitest/mocker': 2.1.3(@vitest/spy@2.1.3)(vite@5.2.11(@types/node@20.12.12)(terser@5.31.0))
+      '@vitest/pretty-format': 2.1.3
+      '@vitest/runner': 2.1.3
+      '@vitest/snapshot': 2.1.3
+      '@vitest/spy': 2.1.3
+      '@vitest/utils': 2.1.3
       chai: 5.1.1
       debug: 4.3.6
       magic-string: 0.30.11
@@ -3949,7 +3847,7 @@ snapshots:
       tinypool: 1.0.1
       tinyrainbow: 1.2.0
       vite: 5.2.11(@types/node@20.12.12)(terser@5.31.0)
-      vite-node: 2.1.2(@types/node@20.12.12)(terser@5.31.0)
+      vite-node: 2.1.3(@types/node@20.12.12)(terser@5.31.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.12.12

--- a/src/database.ts
+++ b/src/database.ts
@@ -2,8 +2,6 @@ import SqliteDatabase from 'better-sqlite3'
 import { CamelCasePlugin, Kysely, SqliteDialect } from 'kysely'
 import memoize from 'memoize'
 
-import { env } from './env.js'
-
 type SlackWorkspaceId = string & { __brand: 'slackWorkspaceId' }
 type UserId = string & { __brand: 'userId' }
 
@@ -46,7 +44,7 @@ type Database = {
 
 type KyselyDb = Kysely<Database>
 
-const getDb = memoize((dbPath: string = env.DB_PATH): KyselyDb => {
+const getDb = memoize((dbPath: string): KyselyDb => {
   return new Kysely({
     dialect: new SqliteDialect({
       database: async () => new SqliteDatabase(dbPath),

--- a/src/database.ts
+++ b/src/database.ts
@@ -1,5 +1,6 @@
 import SqliteDatabase from 'better-sqlite3'
 import { CamelCasePlugin, Kysely, SqliteDialect } from 'kysely'
+import memoize from 'memoize'
 
 import { env } from './env.js'
 
@@ -45,11 +46,13 @@ type Database = {
 
 type KyselyDb = Kysely<Database>
 
-const db: KyselyDb = new Kysely({
-  dialect: new SqliteDialect({
-    database: async () => new SqliteDatabase(env.DB_PATH),
-  }),
-  plugins: [new CamelCasePlugin()],
+const getDb = memoize((dbPath: string = env.DB_PATH): KyselyDb => {
+  return new Kysely({
+    dialect: new SqliteDialect({
+      database: async () => new SqliteDatabase(dbPath),
+    }),
+    plugins: [new CamelCasePlugin()],
+  })
 })
 
 export type {
@@ -63,4 +66,4 @@ export type {
   SlackInstallation,
   KyselyDb,
 }
-export { db }
+export { getDb }

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,16 +1,36 @@
 import * as process from 'node:process'
+import memoize from 'memoize'
 import { z } from 'zod'
 import 'dotenv/config'
 
-const $env = z.object({
-  DB_PATH: z.string().default('state.db'),
-  SLACK_CLIENT_ID: z.string(),
-  SLACK_CLIENT_SECRET: z.string(),
-  SLACK_SIGNING_SECRET: z.string(),
-  SLACK_STATE_SECRET: z.string(),
-  PORT: z.coerce.number().min(1).default(3000),
+const getSlackConfig = memoize(() => {
+  const $env = z.object({
+    SLACK_CLIENT_ID: z.string(),
+    SLACK_CLIENT_SECRET: z.string(),
+    SLACK_SIGNING_SECRET: z.string(),
+    SLACK_STATE_SECRET: z.string(),
+  })
+  const config = $env.parse(process.env)
+  return {
+    clientId: config.SLACK_CLIENT_ID,
+    clientSecret: config.SLACK_CLIENT_SECRET,
+    signingSecret: config.SLACK_SIGNING_SECRET,
+    stateSecret: config.SLACK_STATE_SECRET,
+  }
 })
 
-const env = $env.parse(process.env)
+const getDbPath = memoize(() => {
+  const $env = z.object({
+    DB_PATH: z.string().default('state.db'),
+  })
+  return $env.parse(process.env).DB_PATH
+})
 
-export { env }
+const getPort = memoize(() => {
+  const $env = z.object({
+    PORT: z.coerce.number().min(1).default(3000),
+  })
+  return $env.parse(process.env).PORT
+})
+
+export { getSlackConfig, getDbPath, getPort }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,16 @@
 import { getDb } from './database.js'
 import { migrateToLatest } from './migrate.js'
 
-import { env } from './env.js'
+import { getDbPath, getPort, getSlackConfig } from './env.js'
 import { createClient } from './slack/client.js'
 
-const db = getDb()
+const dbPath = getDbPath()
+const db = getDb(dbPath)
 
 await migrateToLatest(db)
 
 await createClient({
   db,
-  slackClientId: env.SLACK_CLIENT_ID,
-  slackClientSecret: env.SLACK_CLIENT_SECRET,
-  slackSigningSecret: env.SLACK_SIGNING_SECRET,
-  slackStateSecret: env.SLACK_STATE_SECRET,
-  port: env.PORT,
+  port: getPort(),
+  slack: getSlackConfig(),
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,10 @@
-import { db } from './database.js'
+import { getDb } from './database.js'
 import { migrateToLatest } from './migrate.js'
 
 import { env } from './env.js'
 import { createClient } from './slack/client.js'
+
+const db = getDb()
 
 await migrateToLatest(db)
 

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -1,23 +1,22 @@
-import { promises as fs } from 'node:fs'
-import * as path from 'node:path'
-import { fileURLToPath } from 'node:url'
-import { FileMigrationProvider, type Kysely, Migrator } from 'kysely'
+import { type Kysely, type MigrationProvider, Migrator } from 'kysely'
 
 import type { Database } from './database.js'
 
-const migrationFolder = path.join(
-  path.dirname(fileURLToPath(import.meta.url)),
-  'migrations',
-)
+const migrationProvider = {
+  getMigrations: async () => {
+    return {
+      '2024-05-31': await import('./migrations/2024-05-31-init.js'),
+      '2024-10-14': await import(
+        './migrations/2024-10-14-installation-store.js'
+      ),
+    }
+  },
+} satisfies MigrationProvider
 
 const migrateToLatest = async (db: Kysely<Database>) => {
   const migrator = new Migrator({
     db,
-    provider: new FileMigrationProvider({
-      fs,
-      path,
-      migrationFolder,
-    }),
+    provider: migrationProvider,
   })
 
   const { error, results } = await migrator.migrateToLatest()

--- a/src/slack/client.ts
+++ b/src/slack/client.ts
@@ -1,4 +1,4 @@
-import slack from '@slack/bolt'
+import bolt from '@slack/bolt'
 import { z } from 'zod'
 
 import type { KyselyDb, SlackWorkspaceId, UserId } from '#src/database.js'
@@ -13,28 +13,23 @@ import { createInstallationStore } from '#src/slack/installation-store.js'
 
 type CreateClientOptions = {
   db: KyselyDb
-  slackClientId: string
-  slackClientSecret: string
-  slackSigningSecret: string
-  slackStateSecret: string
   port: number
+  slack: {
+    clientId: string
+    clientSecret: string
+    signingSecret: string
+    stateSecret: string
+  }
 }
 
 const createClient = async (options: CreateClientOptions) => {
-  const {
-    db,
-    slackClientId,
-    slackClientSecret,
-    slackSigningSecret,
-    slackStateSecret,
-    port,
-  } = options
+  const { db, port, slack } = options
 
-  const app = new slack.App({
-    clientId: slackClientId,
-    clientSecret: slackClientSecret,
-    signingSecret: slackSigningSecret,
-    stateSecret: slackStateSecret,
+  const app = new bolt.App({
+    clientId: slack.clientId,
+    clientSecret: slack.clientSecret,
+    signingSecret: slack.signingSecret,
+    stateSecret: slack.stateSecret,
     scopes: ['commands', 'reactions:write', 'users:read', 'team:read'],
     installationStore: createInstallationStore(db),
   })

--- a/src/slack/installation-store.test.ts
+++ b/src/slack/installation-store.test.ts
@@ -1,0 +1,248 @@
+import type { Installation } from '@slack/bolt'
+import { test as anyTest, describe, expect } from 'vitest'
+
+import type { SlackInstallationId } from '#src/database.js'
+
+import { useDb } from '#src/test/use-db.js'
+import { useNow } from '#src/test/use-now.js'
+
+import { createInstallationStore } from './installation-store.js'
+
+const test = anyTest.extend({
+  now: useNow(),
+  db: useDb(),
+})
+
+describe('storeInstallation', () => {
+  test('should store team installation', async ({ now, db }) => {
+    const installationStore = createInstallationStore(db)
+
+    const teamId = 'T001' as SlackInstallationId
+
+    const installation: Installation = {
+      isEnterpriseInstall: false,
+      team: {
+        id: teamId,
+      },
+      enterprise: undefined,
+      user: {
+        id: 'U123',
+        token: 'xoxb-123',
+        scopes: [],
+      },
+    }
+
+    await installationStore.storeInstallation(installation)
+
+    const row = await db
+      .selectFrom('slackInstallation')
+      .selectAll('slackInstallation')
+      .where('id', '=', teamId)
+      .executeTakeFirstOrThrow()
+
+    expect(row).toEqual({
+      id: teamId,
+      value: JSON.stringify(installation),
+      createdAt: now,
+      updatedAt: now,
+    })
+  })
+
+  test('should store enterprise installation', async ({ now, db }) => {
+    const installationStore = createInstallationStore(db)
+
+    const enterpriseId = 'E001' as SlackInstallationId
+
+    const installation: Installation = {
+      isEnterpriseInstall: true,
+      team: undefined,
+      enterprise: {
+        id: enterpriseId,
+      },
+      user: {
+        id: 'U123',
+        token: 'xoxb-123',
+        scopes: [],
+      },
+    }
+
+    await installationStore.storeInstallation(installation)
+
+    const row = await db
+      .selectFrom('slackInstallation')
+      .selectAll('slackInstallation')
+      .where('id', '=', enterpriseId)
+      .executeTakeFirstOrThrow()
+
+    expect(row).toEqual({
+      id: enterpriseId,
+      value: JSON.stringify(installation),
+      createdAt: now,
+      updatedAt: now,
+    })
+  })
+})
+
+describe('fetchInstallation', () => {
+  test('should fetch team installation', async ({ now, db }) => {
+    const installationStore = createInstallationStore(db)
+
+    const teamId = 'T002' as SlackInstallationId
+
+    const installation: Installation = {
+      isEnterpriseInstall: false,
+      team: {
+        id: teamId,
+      },
+      enterprise: undefined,
+      user: {
+        id: 'U123',
+        token: 'xoxb-123',
+        scopes: [],
+      },
+    }
+
+    await db
+      .insertInto('slackInstallation')
+      .values({
+        id: teamId,
+        value: JSON.stringify(installation),
+        createdAt: now,
+        updatedAt: now,
+      })
+      .execute()
+
+    const fetchedInstallation = await installationStore.fetchInstallation({
+      isEnterpriseInstall: false,
+      teamId,
+      enterpriseId: undefined,
+    })
+
+    expect(fetchedInstallation).toEqual(installation)
+  })
+
+  test('should fetch enterprise installation', async ({ now, db }) => {
+    const installationStore = createInstallationStore(db)
+
+    const enterpriseId = 'E002' as SlackInstallationId
+
+    const installation: Installation = {
+      isEnterpriseInstall: true,
+      team: undefined,
+      enterprise: {
+        id: enterpriseId,
+      },
+      user: {
+        id: 'U123',
+        token: 'xoxb-123',
+        scopes: [],
+      },
+    }
+
+    await db
+      .insertInto('slackInstallation')
+      .values({
+        id: enterpriseId,
+        value: JSON.stringify(installation),
+        createdAt: now,
+        updatedAt: now,
+      })
+      .execute()
+
+    const fetchedInstallation = await installationStore.fetchInstallation({
+      isEnterpriseInstall: true,
+      enterpriseId,
+      teamId: undefined,
+    })
+
+    expect(fetchedInstallation).toEqual(installation)
+  })
+})
+
+describe('deleteInstallation', () => {
+  test('should delete team installation', async ({ now, db }) => {
+    const installationStore = createInstallationStore(db)
+
+    const teamId = 'T003' as SlackInstallationId
+
+    const installation: Installation = {
+      isEnterpriseInstall: false,
+      team: {
+        id: teamId,
+      },
+      enterprise: undefined,
+      user: {
+        id: 'U123',
+        token: 'xoxb-123',
+        scopes: [],
+      },
+    }
+
+    await db
+      .insertInto('slackInstallation')
+      .values({
+        id: teamId,
+        value: JSON.stringify(installation),
+        createdAt: now,
+        updatedAt: now,
+      })
+      .execute()
+
+    await installationStore.deleteInstallation?.({
+      isEnterpriseInstall: false,
+      teamId,
+      enterpriseId: undefined,
+    })
+
+    const row = await db
+      .selectFrom('slackInstallation')
+      .selectAll('slackInstallation')
+      .where('id', '=', teamId)
+      .executeTakeFirst()
+
+    expect(row).toBeUndefined()
+  })
+
+  test('should delete enterprise installation', async ({ now, db }) => {
+    const installationStore = createInstallationStore(db)
+
+    const enterpriseId = 'E003' as SlackInstallationId
+
+    const installation: Installation = {
+      isEnterpriseInstall: true,
+      team: undefined,
+      enterprise: {
+        id: enterpriseId,
+      },
+      user: {
+        id: 'U123',
+        token: 'xoxb-123',
+        scopes: [],
+      },
+    }
+
+    await db
+      .insertInto('slackInstallation')
+      .values({
+        id: enterpriseId,
+        value: JSON.stringify(installation),
+        createdAt: now,
+        updatedAt: now,
+      })
+      .execute()
+
+    await installationStore.deleteInstallation?.({
+      isEnterpriseInstall: true,
+      enterpriseId,
+      teamId: undefined,
+    })
+
+    const row = await db
+      .selectFrom('slackInstallation')
+      .selectAll('slackInstallation')
+      .where('id', '=', enterpriseId)
+      .executeTakeFirst()
+
+    expect(row).toBeUndefined()
+  })
+})

--- a/src/slack/installation-store.ts
+++ b/src/slack/installation-store.ts
@@ -41,6 +41,8 @@ const getInstallationId = (
 const createInstallationStore = (db: KyselyDb): InstallationStore => {
   return {
     storeInstallation: async (installation) => {
+      console.dir({ storeInstallation: installation }, { depth: null })
+
       const installationId = getInstallationId(installation)
 
       const result = await errorBoundary(() =>
@@ -60,6 +62,8 @@ const createInstallationStore = (db: KyselyDb): InstallationStore => {
       }
     },
     fetchInstallation: async (installQuery) => {
+      console.dir({ fetchInstallation: installQuery }, { depth: null })
+
       const installationId = getInstallationId(installQuery)
 
       const installation = await errorBoundary(async () => {
@@ -71,6 +75,7 @@ const createInstallationStore = (db: KyselyDb): InstallationStore => {
 
         return JSON.parse(row.value) as Installation
       })
+      console.dir({ installationId, installation }, { depth: null })
       if (installation instanceof Error) {
         console.error(installation)
         throw new Error('Failed fetching installation')

--- a/src/test/use-db.ts
+++ b/src/test/use-db.ts
@@ -1,0 +1,26 @@
+import memoize from 'memoize'
+
+import type { KyselyDb } from '#src/database.js'
+
+import { getDb } from '#src/database.js'
+import { migrateToLatest } from '#src/migrate.js'
+
+// ensure only one instance of the in-memory database for all tests
+const getInMemoryDb = memoize(async () => {
+  const db = getDb(':memory:')
+  await migrateToLatest(db)
+  return db
+})
+
+const useDb = () => {
+  return async (
+    // biome-ignore lint/correctness/noEmptyPattern: vitest requires {}
+    {}: Record<string, unknown>,
+    use: (db: KyselyDb) => Promise<void>,
+  ) => {
+    const db = await getInMemoryDb()
+    await use(db)
+  }
+}
+
+export { useDb }

--- a/src/test/use-now.ts
+++ b/src/test/use-now.ts
@@ -1,0 +1,14 @@
+import { vi } from 'vitest'
+
+const useNow =
+  (now: number = Date.now()) =>
+  async (
+    // biome-ignore lint/correctness/noEmptyPattern: vitest requires {}
+    {}: Record<string, unknown>,
+    use: (now: number) => Promise<void>,
+  ) => {
+    vi.setSystemTime(now)
+    await use(now)
+  }
+
+export { useNow }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,32 +1,32 @@
 {
-	"compilerOptions": {
+  "compilerOptions": {
     "noEmit": true,
-		"outDir": "dist",
+    "outDir": "dist",
 
-		// Enable latest features
-		"lib": ["ESNext"],
-		"target": "ESNext",
-		"module": "ESNext",
-		"moduleDetection": "force",
-		"jsx": "react-jsx",
-		"allowJs": true,
+    // Enable latest features
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
 
-		// Bundler mode
-		"moduleResolution": "bundler",
-		"verbatimModuleSyntax": true,
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
 
-		// Best practices
-		"strict": true,
-		"skipLibCheck": true,
-		"noFallthroughCasesInSwitch": true,
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
 
-		// Some stricter flags (disabled by default)
-		"noUnusedLocals": false,
-		"noUnusedParameters": false,
-		"noPropertyAccessFromIndexSignature": false,
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false,
 
     "paths": {
       "#src/*": ["./src/*"]
     }
-	}
+  }
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,8 +1,8 @@
-import { defineConfig } from "tsup"
+import { defineConfig } from 'tsup'
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/migrations/*.ts"],
-  format: ["esm"],
+  entry: ['src/index.ts', 'src/migrations/*.ts'],
+  format: ['esm'],
   clean: true,
-  target: "node22",
+  target: 'node22',
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vitest/config"
+import tsconfigPaths from 'vite-tsconfig-paths'
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "vitest/config"
 import tsconfigPaths from 'vite-tsconfig-paths'
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   plugins: [tsconfigPaths()],


### PR DESCRIPTION
- Modified package.json:
  - Updated test script to run vitest in watch mode
  - Added memoize and vite-tsconfig-paths dependencies
- Updated database.ts:
  - Introduced memoized getDb function for flexible DB initialization
- Refactored index.ts to use the new getDb function
- Updated migrate.ts to use an inline migration provider
- Added comprehensive tests for installation-store.ts
- Created utility functions use-db.ts and use-now.ts for testing
- Added vitest.config.ts to configure test environment

These changes improve the testing infrastructure and database handling in the project. The installation store now has thorough tests, and the database connection is more flexible and testable.