### PR TITLE
refactor: Simplify migration provider and add name exports 🔧

### DIFF
--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -4,12 +4,12 @@ import type { Database } from './database.js'
 
 const migrationProvider = {
   getMigrations: async () => {
-    return {
-      '2024-05-31': await import('./migrations/2024-05-31-init.js'),
-      '2024-10-14': await import(
-        './migrations/2024-10-14-installation-store.js'
-      ),
-    }
+    return Object.fromEntries(
+      [
+        await import('./migrations/2024-05-31-init.js'),
+        await import('./migrations/2024-10-14-installation-store.js'),
+      ].map((file) => [file.name, file]),
+    )
   },
 } satisfies MigrationProvider
 

--- a/src/migrations/2024-05-31-init.ts
+++ b/src/migrations/2024-05-31-init.ts
@@ -1,5 +1,7 @@
 import type { Kysely } from 'kysely'
 
+export const name = '2024-05-31-init'
+
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema
     .createTable('slack_workspace')

--- a/src/migrations/2024-10-14-installation-store.ts
+++ b/src/migrations/2024-10-14-installation-store.ts
@@ -1,5 +1,7 @@
 import type { Kysely } from 'kysely'
 
+export const name = '2024-10-14-installation-store'
+
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema
     .createTable('slack_installation')


### PR DESCRIPTION
- Changed migration provider in src/migrate.ts to use a more concise approach
- Added name exports to migration files for easier identification
- Modified:
  - src/migrate.ts
  - src/migrations/2024-05-31-init.ts
  - src/migrations/2024-10-14-installation-store.ts

This refactoring improves code readability and makes it easier to manage migrations.