### PR TITLE
feat: Add conflict handling for Slack installation storage 🔄

### DIFF
--- a/src/slack/installation-store.ts
+++ b/src/slack/installation-store.ts
@@ -54,6 +54,12 @@ const createInstallationStore = (db: KyselyDb): InstallationStore => {
             createdAt: Date.now(),
             updatedAt: Date.now(),
           })
+          .onConflict((oc) =>
+            oc.doUpdateSet({
+              value: JSON.stringify(installation),
+              updatedAt: Date.now(),
+            }),
+          )
           .execute(),
       )
       if (result instanceof Error) {


### PR DESCRIPTION
- Updated `storeInstallation` function in `installation-store.ts` to handle conflicts
- Added a new test case in `installation-store.test.ts` to verify overwriting existing installations
- Modified existing test cases to use more distinct team IDs

This change improves the robustness of the Slack installation storage by adding a conflict resolution strategy. Now, when storing an installation, if a record with the same ID already exists, it will be updated instead of causing an error. This ensures that the most recent installation data is always stored, even for existing teams.