### PR TITLE
feat: update dependencies and refactor customer to person 🔄

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@roughapp/slack-bot",
   "private": true,
   "version": "0.13.0",
-  "packageManager": "pnpm@9.15.0",
+  "packageManager": "pnpm@9.15.1",
   "type": "module",
   "main": "./src/index.ts",
   "author": {
@@ -23,10 +23,10 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@roughapp/sdk": "0.2.2",
-    "@slack/bolt": "4.1.1",
+    "@roughapp/sdk": "1.0.0",
+    "@slack/bolt": "4.2.0",
     "@stayradiated/error-boundary": "4.3.0",
-    "arctic": "2.3.1",
+    "arctic": "2.3.3",
     "better-sqlite3": "11.7.0",
     "dotenv": "16.4.7",
     "kysely": "0.27.5",
@@ -37,9 +37,9 @@
     "@biomejs/biome": "1.9.4",
     "@types/better-sqlite3": "7.6.12",
     "@vitest/coverage-v8": "2.1.8",
-    "knip": "5.40.0",
+    "knip": "5.41.1",
     "typescript": "5.7.2",
-    "undici": "7.1.0",
+    "undici": "7.2.0",
     "vite-tsconfig-paths": "5.1.4",
     "vitest": "2.1.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,17 +9,17 @@ importers:
   .:
     dependencies:
       '@roughapp/sdk':
-        specifier: 0.2.2
-        version: 0.2.2
+        specifier: 1.0.0
+        version: 1.0.0
       '@slack/bolt':
-        specifier: 4.1.1
-        version: 4.1.1
+        specifier: 4.2.0
+        version: 4.2.0
       '@stayradiated/error-boundary':
         specifier: 4.3.0
         version: 4.3.0
       arctic:
-        specifier: 2.3.1
-        version: 2.3.1
+        specifier: 2.3.3
+        version: 2.3.3
       better-sqlite3:
         specifier: 11.7.0
         version: 11.7.0
@@ -46,14 +46,14 @@ importers:
         specifier: 2.1.8
         version: 2.1.8(vitest@2.1.8(@types/node@20.12.12)(terser@5.31.0))
       knip:
-        specifier: 5.40.0
-        version: 5.40.0(@types/node@20.12.12)(typescript@5.7.2)
+        specifier: 5.41.1
+        version: 5.41.1(@types/node@20.12.12)(typescript@5.7.2)
       typescript:
         specifier: 5.7.2
         version: 5.7.2
       undici:
-        specifier: 7.1.0
-        version: 7.1.0
+        specifier: 7.2.0
+        version: 7.2.0
       vite-tsconfig-paths:
         specifier: 5.1.4
         version: 5.1.4(typescript@5.7.2)(vite@5.2.11(@types/node@20.12.12)(terser@5.31.0))
@@ -421,32 +421,32 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@roughapp/sdk@0.2.2':
-    resolution: {integrity: sha512-PDufkr99zewd7cOsipi0G0VPlV6yzNWahjekKFwQwKZ6eEb+6TfWJ8tOhyNP+X5LUKeYhu8Q8SQ+O+4FJXHdsQ==}
+  '@roughapp/sdk@1.0.0':
+    resolution: {integrity: sha512-W8gLoBJV7+ifuuFAWcZZ1kqYELa/hjxjmiaE9mOvrQXAcw/gZQicn6URxLNCjpVbmC9Z0sPKrIQQ5tfcT5V57w==}
     engines: {node: ^22.9.0}
 
-  '@slack/bolt@4.1.1':
-    resolution: {integrity: sha512-Sc8QUnEHCPgRlwrMxmvOl4Vhr/7ZBDXvLR0ir6TO+W5MaDtPsrmWLxqLmb+OhCGSjDp3d4AxO6jdFlC3yNKtsg==}
+  '@slack/bolt@4.2.0':
+    resolution: {integrity: sha512-KQGUkC37t6DUR+FVglHmcUrMpdCLbY9wpZXfjW6CUNmQnINits+EeOrVN/5xPcISKJcBIhqgrarLpwU9tpESTw==}
     engines: {node: '>=18', npm: '>=8.6.0'}
 
   '@slack/logger@4.0.0':
     resolution: {integrity: sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
 
-  '@slack/oauth@3.0.1':
-    resolution: {integrity: sha512-TuR9PI6bYKX6qHC7FQI4keMnhj45TNfSNQtTU3mtnHUX4XLM2dYLvRkUNADyiLTle2qu2rsOQtCIsZJw6H0sDA==}
+  '@slack/oauth@3.0.2':
+    resolution: {integrity: sha512-MdPS8AP9n3u/hBeqRFu+waArJLD/q+wOSZ48ktMTwxQLc6HJyaWPf8soqAyS/b0D6IlvI5TxAdyRyyv3wQ5IVw==}
     engines: {node: '>=18', npm: '>=8.6.0'}
 
-  '@slack/socket-mode@2.0.2':
-    resolution: {integrity: sha512-WSLBnGY9eE19jx6QLIP78oFpxNVU74soDIP0dupi35MFY6WfLBAikbuy4Y/rR4v9eJ7MNnd5/BdQNETgv32F8Q==}
+  '@slack/socket-mode@2.0.3':
+    resolution: {integrity: sha512-aY1AhQd3HAgxLYC2Mz47dXtW6asjyYp8bJ24MWalg+qFWPaXj8VBYi+5w3rfGqBW5IxlIhs3vJTEQtIBrqQf5A==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
 
   '@slack/types@2.14.0':
     resolution: {integrity: sha512-n0EGm7ENQRxlXbgKSrQZL69grzg1gHLAVd+GlRVQJ1NSORo0FrApR7wql/gaKdu2n4TO83Sq/AmeUOqD60aXUA==}
     engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
 
-  '@slack/web-api@7.7.0':
-    resolution: {integrity: sha512-DtRyjgQi0mObA2uC6H8nL2OhAISKDhvtOXgRjGRBnBhiaWb6df5vPmKHsOHjpweYALBMHtiqE5ajZFkDW/ag8Q==}
+  '@slack/web-api@7.8.0':
+    resolution: {integrity: sha512-d4SdG+6UmGdzWw38a4sN3lF/nTEzsDxhzU13wm10ejOpPehtmRoqBKnPztQUfFiWbNvSb4czkWYJD4kt+5+Fuw==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
 
   '@snyk/github-codeowners@1.1.0':
@@ -460,47 +460,17 @@ packages:
   '@types/better-sqlite3@7.6.12':
     resolution: {integrity: sha512-fnQmj8lELIj7BSrZQAdBMHEHX8OZLYIHXqAKT1O7tDfLxaINzf00PMjw22r3N/xXh0w/sGHlO6SVaCQ2mj78lg==}
 
-  '@types/body-parser@1.19.5':
-    resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
-
-  '@types/connect@3.4.38':
-    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
-
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
-
-  '@types/express-serve-static-core@4.19.6':
-    resolution: {integrity: sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==}
-
-  '@types/express@4.17.21':
-    resolution: {integrity: sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==}
-
-  '@types/http-errors@2.0.4':
-    resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
 
   '@types/jsonwebtoken@9.0.7':
     resolution: {integrity: sha512-ugo316mmTYBl2g81zDFnZ7cfxlut3o+/EQdaP7J8QN2kY6lJ22hmQYCK5EHcJHbrW+dkCGSCPgbG8JtYj6qSrg==}
 
-  '@types/mime@1.3.5':
-    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
-
   '@types/node@20.12.12':
     resolution: {integrity: sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==}
 
-  '@types/qs@6.9.16':
-    resolution: {integrity: sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==}
-
-  '@types/range-parser@1.2.7':
-    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
-
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
-
-  '@types/send@0.17.4':
-    resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
-
-  '@types/serve-static@1.15.7':
-    resolution: {integrity: sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==}
 
   '@types/ws@8.5.12':
     resolution: {integrity: sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==}
@@ -572,8 +542,8 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
 
-  arctic@2.3.1:
-    resolution: {integrity: sha512-bnmPYWbPtrQcneG/dmZIdvDeZ7pYhHqd4hYTbOR5LB9f429XLHiE4VnmKmJCPkw+G2CsG689WS+NDwa5UKsigA==}
+  arctic@2.3.3:
+    resolution: {integrity: sha512-f42+wyM0LKNwUY0TV3fSH1Fnsr/klcZi42XfWFvlNP7Ag8aBX92FaKQIU5xBQzxvvy7jg02tF567LsIlmEujKg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -588,8 +558,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@1.7.7:
-    resolution: {integrity: sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==}
+  axios@1.7.9:
+    resolution: {integrity: sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1048,8 +1018,8 @@ packages:
   jws@3.2.2:
     resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
 
-  knip@5.40.0:
-    resolution: {integrity: sha512-EzBfQDz4YBzYnMLueWnaaVr15mneqZs1c3RanttciuVuRcodlNjzAmR2nch/khlRdVABAxAdMGFxfSvhvcH1NA==}
+  knip@5.41.1:
+    resolution: {integrity: sha512-yNpCCe2REU7U3VRvMASnXSEtfEC2HmOoDW9Vp9teQ9FktJYnuagvSZD3xWq8Ru7sPABkmvbC5TVWuMzIaeADNA==}
     engines: {node: '>=18.6.0'}
     hasBin: true
     peerDependencies:
@@ -1515,8 +1485,8 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  undici@7.1.0:
-    resolution: {integrity: sha512-3+mdX2R31khuLCm2mKExSlMdJsfol7bJkIMH80tdXA74W34rT1jKemUTlYR7WY3TqsV4wfOgpatWmmB2Jl1+5g==}
+  undici@7.2.0:
+    resolution: {integrity: sha512-klt+0S55GBViA9nsq48/NSCo4YX5mjydjypxD7UmHh/brMu8h/Mhd/F7qAeoH2NOO8SDTk6kjnTFc4WpzmfYpQ==}
     engines: {node: '>=20.18.1'}
 
   unpipe@1.0.0:
@@ -1887,20 +1857,19 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.24.0':
     optional: true
 
-  '@roughapp/sdk@0.2.2':
+  '@roughapp/sdk@1.0.0':
     dependencies:
       '@stayradiated/error-boundary': 4.3.0
-      arctic: 2.3.1
+      arctic: 2.3.3
 
-  '@slack/bolt@4.1.1':
+  '@slack/bolt@4.2.0':
     dependencies:
       '@slack/logger': 4.0.0
-      '@slack/oauth': 3.0.1
-      '@slack/socket-mode': 2.0.2
+      '@slack/oauth': 3.0.2
+      '@slack/socket-mode': 2.0.3
       '@slack/types': 2.14.0
-      '@slack/web-api': 7.7.0
-      '@types/express': 4.17.21
-      axios: 1.7.7
+      '@slack/web-api': 7.8.0
+      axios: 1.7.9
       express: 5.0.1
       path-to-regexp: 8.2.0
       raw-body: 3.0.0
@@ -1915,10 +1884,10 @@ snapshots:
     dependencies:
       '@types/node': 20.12.12
 
-  '@slack/oauth@3.0.1':
+  '@slack/oauth@3.0.2':
     dependencies:
       '@slack/logger': 4.0.0
-      '@slack/web-api': 7.7.0
+      '@slack/web-api': 7.8.0
       '@types/jsonwebtoken': 9.0.7
       '@types/node': 20.12.12
       jsonwebtoken: 9.0.2
@@ -1926,10 +1895,10 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@slack/socket-mode@2.0.2':
+  '@slack/socket-mode@2.0.3':
     dependencies:
       '@slack/logger': 4.0.0
-      '@slack/web-api': 7.7.0
+      '@slack/web-api': 7.8.0
       '@types/node': 20.12.12
       '@types/ws': 8.5.12
       eventemitter3: 5.0.1
@@ -1941,13 +1910,13 @@ snapshots:
 
   '@slack/types@2.14.0': {}
 
-  '@slack/web-api@7.7.0':
+  '@slack/web-api@7.8.0':
     dependencies:
       '@slack/logger': 4.0.0
       '@slack/types': 2.14.0
       '@types/node': 20.12.12
       '@types/retry': 0.12.0
-      axios: 1.7.7
+      axios: 1.7.9
       eventemitter3: 5.0.1
       form-data: 4.0.0
       is-electron: 2.2.2
@@ -1970,59 +1939,17 @@ snapshots:
     dependencies:
       '@types/node': 20.12.12
 
-  '@types/body-parser@1.19.5':
-    dependencies:
-      '@types/connect': 3.4.38
-      '@types/node': 20.12.12
-
-  '@types/connect@3.4.38':
-    dependencies:
-      '@types/node': 20.12.12
-
   '@types/estree@1.0.6': {}
-
-  '@types/express-serve-static-core@4.19.6':
-    dependencies:
-      '@types/node': 20.12.12
-      '@types/qs': 6.9.16
-      '@types/range-parser': 1.2.7
-      '@types/send': 0.17.4
-
-  '@types/express@4.17.21':
-    dependencies:
-      '@types/body-parser': 1.19.5
-      '@types/express-serve-static-core': 4.19.6
-      '@types/qs': 6.9.16
-      '@types/serve-static': 1.15.7
-
-  '@types/http-errors@2.0.4': {}
 
   '@types/jsonwebtoken@9.0.7':
     dependencies:
       '@types/node': 20.12.12
 
-  '@types/mime@1.3.5': {}
-
   '@types/node@20.12.12':
     dependencies:
       undici-types: 5.26.5
 
-  '@types/qs@6.9.16': {}
-
-  '@types/range-parser@1.2.7': {}
-
   '@types/retry@0.12.0': {}
-
-  '@types/send@0.17.4':
-    dependencies:
-      '@types/mime': 1.3.5
-      '@types/node': 20.12.12
-
-  '@types/serve-static@1.15.7':
-    dependencies:
-      '@types/http-errors': 2.0.4
-      '@types/node': 20.12.12
-      '@types/send': 0.17.4
 
   '@types/ws@8.5.12':
     dependencies:
@@ -2109,7 +2036,7 @@ snapshots:
 
   ansi-styles@6.2.1: {}
 
-  arctic@2.3.1:
+  arctic@2.3.3:
     dependencies:
       '@oslojs/crypto': 1.0.1
       '@oslojs/encoding': 1.1.0
@@ -2123,7 +2050,7 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.7.7:
+  axios@1.7.9:
     dependencies:
       follow-redirects: 1.15.9
       form-data: 4.0.0
@@ -2613,7 +2540,7 @@ snapshots:
       jwa: 1.4.1
       safe-buffer: 5.2.1
 
-  knip@5.40.0(@types/node@20.12.12)(typescript@5.7.2):
+  knip@5.41.1(@types/node@20.12.12)(typescript@5.7.2):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
       '@snyk/github-codeowners': 1.1.0
@@ -3082,7 +3009,7 @@ snapshots:
 
   undici-types@5.26.5: {}
 
-  undici@7.1.0: {}
+  undici@7.2.0: {}
 
   unpipe@1.0.0: {}
 

--- a/src/slack/shortcuts/create-insight/create-insight.test.ts
+++ b/src/slack/shortcuts/create-insight/create-insight.test.ts
@@ -162,7 +162,7 @@ test('create an insight with a reference', async ({
   })
 })
 
-test('create an insight with a customer', async ({
+test('create an insight with a person', async ({
   db,
   roughOAuth,
   slackUser,
@@ -186,7 +186,7 @@ test('create an insight with a customer', async ({
   interceptor(getRoughAppUrl())
     .intercept({
       method: 'POST',
-      path: '/api/v1/customer',
+      path: '/api/v1/person',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${slackUser.accessToken}`,
@@ -204,7 +204,7 @@ test('create an insight with a customer', async ({
     slackUserId,
     slackWorkspaceId,
     content: 'hello world this is a particularly insightful insight',
-    customerName: 'Johny Appleseed',
+    personName: 'Johny Appleseed',
   })
 
   expect(result).toStrictEqual({

--- a/src/slack/shortcuts/create-insight/create-insight.ts
+++ b/src/slack/shortcuts/create-insight/create-insight.ts
@@ -1,7 +1,7 @@
 import {
   type RoughOAuth2Provider,
-  createCustomer as rapiCreateCustomer,
   createNote as rapiCreateNote,
+  createPerson as rapiCreatePerson,
   createReference as rapiCreateReference,
 } from '@roughapp/sdk'
 
@@ -27,7 +27,7 @@ type CreateInsightOptions = {
   slackUserId: SlackUserId
   content: string
   referencePath?: string
-  customerName?: string
+  personName?: string
   originalAuthorName?: string
 }
 
@@ -41,7 +41,7 @@ const createInsight = async (
     slackUserId,
     content: originalContent,
     referencePath,
-    customerName,
+    personName,
     originalAuthorName,
   } = options
 
@@ -72,7 +72,7 @@ const createInsight = async (
   }
 
   let referenceId: string | undefined
-  let customerId: string | undefined
+  let personId: string | undefined
 
   if (referencePath) {
     const snippet =
@@ -96,19 +96,19 @@ const createInsight = async (
     referenceId = reference.id
   }
 
-  if (customerName) {
-    const customer = await rapiCreateCustomer({
+  if (personName) {
+    const person = await rapiCreatePerson({
       baseUrl: getRoughAppUrl(),
       apiToken,
-      name: customerName,
+      name: personName,
     })
-    if (customer instanceof Error) {
+    if (person instanceof Error) {
       return {
         success: false,
-        reply: failure('Could not createCustomer', customer),
+        reply: failure('Could not createPerson', person),
       }
     }
-    customerId = customer.id
+    personId = person.id
   }
 
   let content = originalContent
@@ -122,7 +122,7 @@ const createInsight = async (
     content,
     createdByUserId: slackUser.roughUserId,
     referenceId,
-    customerId,
+    personId,
   })
   if (note instanceof Error) {
     return { success: false, reply: failure('Could not createNote', note) }


### PR DESCRIPTION
- Updated multiple package dependencies in package.json:
  - pnpm from 9.15.0 to 9.15.1
  - @roughapp/sdk from 0.2.2 to 1.0.0
  - @slack/bolt from 4.1.1 to 4.2.0
  - arctic from 2.3.1 to 2.3.3
  - knip from 5.40.0 to 5.41.1
  - undici from 7.1.0 to 7.2.0
- Refactored create-insight feature to use "person" terminology instead of "customer":
  - Updated API endpoints from /customer to /person
  - Renamed variables and parameters to match new terminology
  - Updated test descriptions and test cases