### PR TITLE
feat: add support for user email lookup and improve person matching 📧

### DIFF
--- a/manifest.dev.json
+++ b/manifest.dev.json
@@ -31,7 +31,13 @@
       "https://slack-development.rough.app/slack/oauth_redirect"
     ],
     "scopes": {
-      "bot": ["commands", "reactions:write", "users:read", "team:read"]
+      "bot": [
+        "commands",
+        "reactions:write",
+        "team:read",
+        "users:read",
+        "users:read.email"
+      ]
     }
   },
   "settings": {

--- a/manifest.prod.json
+++ b/manifest.prod.json
@@ -29,7 +29,13 @@
   "oauth_config": {
     "redirect_urls": ["https://slack.rough.app/slack/oauth_redirect"],
     "scopes": {
-      "bot": ["commands", "reactions:write", "users:read", "team:read"]
+      "bot": [
+        "commands",
+        "reactions:write",
+        "team:read",
+        "users:read",
+        "users:read.email"
+      ]
     }
   },
   "settings": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@roughapp/slack-bot",
   "private": true,
   "version": "0.14.0",
-  "packageManager": "pnpm@9.15.1",
+  "packageManager": "pnpm@9.15.2",
   "type": "module",
   "main": "./src/index.ts",
   "author": {
@@ -20,10 +20,11 @@
     "knip": "knip",
     "watch": "node --no-warnings --experimental-strip-types --env-file=.env --watch ./src/index.ts",
     "start": "node --no-warnings --experimental-strip-types --env-file=.env ./src/index.ts",
-    "tsc": "tsc"
+    "tsc": "tsc",
+    "check": "tsc"
   },
   "dependencies": {
-    "@roughapp/sdk": "1.0.0",
+    "@roughapp/sdk": "1.2.1",
     "@slack/bolt": "4.2.0",
     "@stayradiated/error-boundary": "4.3.0",
     "arctic": "2.3.3",
@@ -44,6 +45,6 @@
     "vitest": "2.1.8"
   },
   "engines": {
-    "node": "^22.9.0"
+    "node": "^23.5.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@roughapp/sdk':
-        specifier: 1.0.0
-        version: 1.0.0
+        specifier: 1.2.1
+        version: 1.2.1
       '@slack/bolt':
         specifier: 4.2.0
         version: 4.2.0
@@ -421,8 +421,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@roughapp/sdk@1.0.0':
-    resolution: {integrity: sha512-W8gLoBJV7+ifuuFAWcZZ1kqYELa/hjxjmiaE9mOvrQXAcw/gZQicn6URxLNCjpVbmC9Z0sPKrIQQ5tfcT5V57w==}
+  '@roughapp/sdk@1.2.1':
+    resolution: {integrity: sha512-B/HhiySKjJKMUtN6gU7kK9Bd7ZDrWkodGGC9r9u+y4L34vdHsI1VojIYJX7uEg8JUSSm2TMiaPoGxiRD3aQfBA==}
     engines: {node: ^22.9.0}
 
   '@slack/bolt@4.2.0':
@@ -1857,7 +1857,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.24.0':
     optional: true
 
-  '@roughapp/sdk@1.0.0':
+  '@roughapp/sdk@1.2.1':
     dependencies:
       '@stayradiated/error-boundary': 4.3.0
       arctic: 2.3.3

--- a/src/slack/message.test.ts
+++ b/src/slack/message.test.ts
@@ -1,10 +1,24 @@
 import { describe, test } from 'vitest'
 
+import type { LookupUserIdFn } from './lookup-user-id.js'
+
 import { getMessageText, markdownifyLinks, resolveMentions } from './message.js'
 
-const lookupUserId = async (userId: string) => {
-  if (userId === 'U123') return 'johndoe'
-  if (userId === 'U456') return 'janedoe'
+const lookupUserId: LookupUserIdFn = async (userId) => {
+  if (userId === 'U123') {
+    return {
+      displayName: 'johndoe',
+      realName: 'John Doe',
+      email: 'john.doe@gmail.com',
+    }
+  }
+  if (userId === 'U456') {
+    return {
+      displayName: 'janedoe',
+      realName: 'Jane Doe',
+      email: 'jane.doe@gmail.com',
+    }
+  }
   return new Error('User not found')
 }
 

--- a/src/slack/message.ts
+++ b/src/slack/message.ts
@@ -1,10 +1,12 @@
+import type { LookupUserIdFn } from './lookup-user-id.ts'
+
 /*
  * replaces user mentions in the message with the user's name
  * i.e. <@U07R8566MHN> becomes @johndoe
  */
 
 type ResolveMentionsOptions = {
-  lookupUserId: (userId: string) => Promise<string | Error>
+  lookupUserId: LookupUserIdFn
   messageText: string
 }
 
@@ -19,11 +21,14 @@ const resolveMentions = async (
   // Step 1: Look up all user IDs asynchronously and store results in a Map
   const userMap = new Map<string, string>()
   for (const [, userId] of userMentions) {
-    const userName = await lookupUserId(userId)
-    if (userName instanceof Error) {
+    const profile = await lookupUserId(userId)
+    if (profile instanceof Error) {
       continue
     }
-    userMap.set(userId, `@${userName}`)
+    userMap.set(
+      userId,
+      `@${profile.displayName ?? profile.realName ?? 'Anonymous'}`,
+    )
   }
 
   // Step 2: Replace all mentions with names using the Map
@@ -60,7 +65,7 @@ const markdownifyLinks = async (
  */
 
 type GetMessageTextOptions = {
-  lookupUserId: (userId: string) => Promise<string | Error>
+  lookupUserId: LookupUserIdFn
   messageText: string
 }
 

--- a/src/slack/shortcuts/create-insight/create-insight.test.ts
+++ b/src/slack/shortcuts/create-insight/create-insight.test.ts
@@ -185,6 +185,17 @@ test('create an insight with a person', async ({
 
   interceptor(getRoughAppUrl())
     .intercept({
+      method: 'GET',
+      path: '/api/v1/person?name=Johny+Appleseed',
+      headers: {
+        Authorization: `Bearer ${slackUser.accessToken}`,
+      },
+    })
+    .reply(200, [])
+    .times(1)
+
+  interceptor(getRoughAppUrl())
+    .intercept({
       method: 'POST',
       path: '/api/v1/person',
       headers: {
@@ -204,7 +215,10 @@ test('create an insight with a person', async ({
     slackUserId,
     slackWorkspaceId,
     content: 'hello world this is a particularly insightful insight',
-    personName: 'Johny Appleseed',
+    originalAuthor: {
+      name: 'Johny Appleseed',
+      email: undefined,
+    },
   })
 
   expect(result).toStrictEqual({

--- a/src/slack/shortcuts/create-insight/shortcut.ts
+++ b/src/slack/shortcuts/create-insight/shortcut.ts
@@ -90,14 +90,17 @@ const getShortcut =
     })
 
     // Optionally, modify the message content if it's not authored by the user submitting the insight
-    let originalAuthorName: string | undefined
+    let originalAuthor: { name: string; email: string | undefined } | undefined
     const messageAuthorUserId = message.user as SlackUserId | undefined
     if (messageAuthorUserId && messageAuthorUserId !== slackuser.slackUserId) {
-      const authorName = await lookupUserId(messageAuthorUserId)
-      if (authorName instanceof Error) {
-        console.error(authorName)
+      const profile = await lookupUserId(messageAuthorUserId)
+      if (profile instanceof Error) {
+        console.error(profile)
       } else {
-        originalAuthorName = authorName
+        originalAuthor = {
+          name: profile.displayName ?? profile.realName ?? 'Anonymous',
+          email: profile.email,
+        }
       }
     }
 
@@ -112,7 +115,7 @@ const getShortcut =
       slackUserId: body.user.id as SlackUserId,
       content,
       referencePath,
-      originalAuthorName,
+      originalAuthor,
     })
 
     if (isSuccess) {


### PR DESCRIPTION
- Modified Slack manifests to include `users:read.email` scope
- Updated `lookup-user-id.ts` to return user profile with email, real name and display name
- Enhanced person matching in create-insight functionality to use email for better identification
- Updated tests to accommodate new user profile structure
- Updated PNPM, Node.js and SDK dependencies to latest versions