### PR TITLE
feat: add tests for Slack user CRUD operations 🚀

### DIFF
--- a/src/db/slack-user/delete-slack-user.test.ts
+++ b/src/db/slack-user/delete-slack-user.test.ts
@@ -1,0 +1,45 @@
+import { assertOk } from '@stayradiated/error-boundary'
+import { test as anyTest } from 'vitest'
+
+import type { SlackUserId, SlackWorkspaceId } from '#src/database.js'
+
+import { useDb } from '#src/test/use-db.js'
+import { useSlackUser } from '#src/test/use-slack-user.ts'
+
+import { deleteSlackUser } from './delete-slack-user.js'
+
+const test = anyTest.extend({
+  db: useDb(),
+  slackUser: useSlackUser(),
+})
+
+test('should succeed, even if the user does not exist', async ({
+  expect,
+  db,
+}) => {
+  const result = await deleteSlackUser({
+    db,
+    where: {
+      slackWorkspaceId: '-' as SlackWorkspaceId,
+      slackUserId: '-' as SlackUserId,
+    },
+  })
+  assertOk(result)
+  expect(result).toBe(0)
+})
+
+test('should delete the user if they exist', async ({
+  expect,
+  db,
+  slackUser,
+}) => {
+  const result = await deleteSlackUser({
+    db,
+    where: {
+      slackWorkspaceId: slackUser.slackWorkspaceId,
+      slackUserId: slackUser.slackUserId,
+    },
+  })
+  assertOk(result)
+  expect(result).toBe(1)
+})

--- a/src/db/slack-user/get-slack-user.test.ts
+++ b/src/db/slack-user/get-slack-user.test.ts
@@ -1,0 +1,41 @@
+import { assertOk } from '@stayradiated/error-boundary'
+import { test as anyTest } from 'vitest'
+
+import type { SlackUserId, SlackWorkspaceId } from '#src/database.js'
+
+import { useDb } from '#src/test/use-db.js'
+import { useSlackUser } from '#src/test/use-slack-user.ts'
+
+import { getSlackUser } from './get-slack-user.js'
+
+const test = anyTest.extend({
+  db: useDb(),
+  slackUser: useSlackUser(),
+})
+
+test('should return undefined if the user does not exist', async ({
+  expect,
+  db,
+}) => {
+  const result = await getSlackUser({
+    db,
+    where: {
+      slackWorkspaceId: '-' as SlackWorkspaceId,
+      slackUserId: '-' as SlackUserId,
+    },
+  })
+  assertOk(result)
+  expect(result).toBe(undefined)
+})
+
+test('should get the user if they exist', async ({ expect, db, slackUser }) => {
+  const result = await getSlackUser({
+    db,
+    where: {
+      slackWorkspaceId: slackUser.slackWorkspaceId,
+      slackUserId: slackUser.slackUserId,
+    },
+  })
+  assertOk(result)
+  expect(result).toStrictEqual(slackUser)
+})

--- a/src/db/slack-user/update-slack-user.test.ts
+++ b/src/db/slack-user/update-slack-user.test.ts
@@ -1,0 +1,79 @@
+import { assertError, assertOk } from '@stayradiated/error-boundary'
+import { test as anyTest } from 'vitest'
+
+import type { SlackUserId, SlackWorkspaceId } from '#src/database.js'
+
+import { useDb } from '#src/test/use-db.js'
+import { useSlackUser } from '#src/test/use-slack-user.ts'
+
+import { updateSlackUser } from './update-slack-user.js'
+
+const test = anyTest.extend({
+  db: useDb(),
+  slackUser: useSlackUser(),
+})
+
+test('should throw error if the user does not exist', async ({
+  expect,
+  db,
+}) => {
+  const result = await updateSlackUser({
+    db,
+    where: {
+      slackWorkspaceId: '-' as SlackWorkspaceId,
+      slackUserId: '-' as SlackUserId,
+    },
+    set: {},
+  })
+  assertError(result)
+  expect(result).toMatchInlineSnapshot('[Error: no result]')
+})
+
+test('should always bump `updatedAt` timestamp', async ({
+  expect,
+  db,
+  slackUser,
+}) => {
+  const result = await updateSlackUser({
+    db,
+    where: {
+      slackWorkspaceId: slackUser.slackWorkspaceId,
+      slackUserId: slackUser.slackUserId,
+    },
+    set: {
+      // intentionally not updating any properties
+    },
+  })
+  assertOk(result)
+  expect(result).toStrictEqual({
+    ...slackUser,
+    updatedAt: expect.any(Number),
+  })
+  expect(result.updatedAt).toBeGreaterThan(slackUser.updatedAt)
+})
+
+test('should update slackUser fields', async ({ expect, db, slackUser }) => {
+  const set = {
+    accessToken: 'UPDATED_ACCESS_TOKEN',
+    accessTokenExpiresAt: Date.now(),
+    refreshToken: 'UPDATED_REFRESH_TOKEN',
+    name: 'UPDATED_NAME',
+  }
+  const result = await updateSlackUser({
+    db,
+    where: {
+      slackWorkspaceId: slackUser.slackWorkspaceId,
+      slackUserId: slackUser.slackUserId,
+    },
+    set,
+  })
+  assertOk(result)
+  expect(result).toStrictEqual({
+    ...slackUser,
+    accessToken: set.accessToken,
+    accessTokenExpiresAt: set.accessTokenExpiresAt,
+    refreshToken: set.refreshToken,
+    name: set.name,
+    updatedAt: expect.any(Number),
+  })
+})

--- a/src/get-or-refresh-access-token.test.ts
+++ b/src/get-or-refresh-access-token.test.ts
@@ -1,0 +1,154 @@
+import { assertError, assertOk } from '@stayradiated/error-boundary'
+import { OAuth2RequestError } from 'arctic'
+import { test as anyTest, beforeEach, describe, vi } from 'vitest'
+
+import { getOrRefreshAccessToken } from './get-or-refresh-access-token.js'
+
+import { mockDb } from '#src/test/mock-db.ts'
+import { mockRoughOAuth } from './test/mock-rough-oauth.js'
+import { mockSlackUser } from './test/mock-slack-user.js'
+
+import { deleteSlackUser } from '#src/db/slack-user/delete-slack-user.ts'
+import { updateSlackUser } from '#src/db/slack-user/update-slack-user.ts'
+
+vi.mock('#src/db/slack-user/update-slack-user.ts')
+vi.mock('#src/db/slack-user/delete-slack-user.ts')
+
+const test = anyTest.extend({
+  db: mockDb(),
+  roughOAuth: mockRoughOAuth(),
+  slackUser: mockSlackUser(),
+})
+
+describe('getOrRefreshAccessToken', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  test('if the access token is not expired, should return the access token', async ({
+    expect,
+    db,
+    roughOAuth,
+    slackUser,
+  }) => {
+    // expires in 5 minutes
+    slackUser.accessTokenExpiresAt = Date.now() + 60 * 5 * 1000
+    const result = await getOrRefreshAccessToken({ db, roughOAuth, slackUser })
+
+    // should NOT have called the refresh token
+    expect(roughOAuth.refreshAccessToken).not.toHaveBeenCalled()
+
+    // should NOT have touched the db
+    expect(updateSlackUser).not.toHaveBeenCalledOnce()
+    expect(deleteSlackUser).not.toHaveBeenCalled()
+
+    assertOk(result)
+    expect(result).toStrictEqual(slackUser.accessToken)
+  })
+
+  test('if the access is expired, should successfully refresh the access token', async ({
+    expect,
+    db,
+    roughOAuth,
+    slackUser,
+  }) => {
+    const nextTokens = {
+      accessToken: 'refreshed.access.token',
+      accessTokenExpiresAt: Date.now() + 60 * 5 * 1000,
+      refreshToken: 'refreshed.refresh.token',
+    }
+    vi.mocked(roughOAuth.refreshAccessToken).mockResolvedValue(nextTokens)
+
+    // expired token
+    slackUser.accessTokenExpiresAt = Date.now()
+    const result = await getOrRefreshAccessToken({ db, roughOAuth, slackUser })
+
+    // should have called the refresh token
+    expect(roughOAuth.refreshAccessToken).toHaveBeenCalledOnce()
+
+    // should have updated the db
+    expect(updateSlackUser).toHaveBeenCalledOnce()
+    expect(updateSlackUser).toHaveBeenCalledWith({
+      db,
+      where: {
+        slackUserId: slackUser.slackUserId,
+        slackWorkspaceId: slackUser.slackWorkspaceId,
+      },
+      set: {
+        accessToken: nextTokens.accessToken,
+        accessTokenExpiresAt: nextTokens.accessTokenExpiresAt,
+        refreshToken: nextTokens.refreshToken,
+      },
+    })
+
+    // should NOT have deleted the slack user
+    expect(deleteSlackUser).not.toHaveBeenCalled()
+
+    assertOk(result)
+    expect(result).toStrictEqual(nextTokens.accessToken)
+  })
+
+  test('if an error occurs while refreshing the access token, should return the error', async ({
+    expect,
+    db,
+    roughOAuth,
+    slackUser,
+  }) => {
+    const error = new Error('something went wrong')
+    vi.mocked(roughOAuth.refreshAccessToken).mockResolvedValue(error)
+
+    // expired token
+    slackUser.accessTokenExpiresAt = Date.now()
+    const result = await getOrRefreshAccessToken({ db, roughOAuth, slackUser })
+
+    // should have called the refresh token
+    expect(roughOAuth.refreshAccessToken).toHaveBeenCalledOnce()
+
+    // should NOT have updated the db
+    expect(updateSlackUser).not.toHaveBeenCalled()
+
+    // should NOT have deleted the slack user
+    expect(deleteSlackUser).not.toHaveBeenCalledOnce()
+
+    assertError(result)
+    expect(result).toStrictEqual(error)
+  })
+
+  test('if the refresh token is expired, should delete the slack user', async ({
+    expect,
+    db,
+    roughOAuth,
+    slackUser,
+  }) => {
+    const error = new OAuth2RequestError(
+      'invalid_grant',
+      'Refresh token expired',
+      null,
+      null,
+    )
+    vi.mocked(roughOAuth.refreshAccessToken).mockResolvedValue(error)
+
+    // expired token
+    slackUser.accessTokenExpiresAt = Date.now()
+    const result = await getOrRefreshAccessToken({ db, roughOAuth, slackUser })
+
+    // should have called the refresh token
+    expect(roughOAuth.refreshAccessToken).toHaveBeenCalledOnce()
+
+    // should NOT have updated the db
+    expect(updateSlackUser).not.toHaveBeenCalled()
+
+    // should have deleted the slack user
+    expect(deleteSlackUser).toHaveBeenCalledOnce()
+    expect(deleteSlackUser).toHaveBeenCalledWith({
+      db,
+      where: {
+        slackUserId: slackUser.slackUserId,
+        slackWorkspaceId: slackUser.slackWorkspaceId,
+      },
+    })
+
+    assertError(result)
+    expect(result).toStrictEqual(error)
+  })
+})

--- a/src/test/mock-db.ts
+++ b/src/test/mock-db.ts
@@ -1,0 +1,25 @@
+import { defineFactory } from 'test-fixture-factory'
+
+import type { KyselyDb } from '#src/database.ts'
+
+const dbFactory = defineFactory<
+  Record<string, unknown>, // no deps
+  void, // no attributes
+  KyselyDb // returns a (mocked) db instance
+>(
+  (
+    // biome-ignore lint/correctness/noEmptyPattern: vitest requires {}
+    {}: Record<string, unknown>,
+    _attrs,
+  ) => {
+    const db = 'MOCK_DB' as unknown as KyselyDb
+
+    return {
+      value: db,
+    }
+  },
+)
+
+const mockDb = dbFactory.useValueFn
+
+export { mockDb }

--- a/src/test/mock-rough-oauth.ts
+++ b/src/test/mock-rough-oauth.ts
@@ -1,0 +1,24 @@
+import type { RoughOAuth2Provider } from '@roughapp/sdk'
+import { defineFactory } from 'test-fixture-factory'
+import { vi } from 'vitest'
+
+const roughOAuthFactory = defineFactory<
+  Record<string, unknown>, // no deps
+  void, // no attributes
+  RoughOAuth2Provider // returns a roughOAuth instance
+>(() => {
+  const roughOAuth = {
+    createAuthorizationURL: vi.fn(),
+    validateAuthorizationCode: vi.fn(),
+    refreshAccessToken: vi.fn(),
+    revokeToken: vi.fn(),
+  } satisfies RoughOAuth2Provider
+
+  return {
+    value: roughOAuth,
+  }
+})
+
+const mockRoughOAuth = roughOAuthFactory.useValueFn
+
+export { mockRoughOAuth }

--- a/src/test/mock-slack-user.ts
+++ b/src/test/mock-slack-user.ts
@@ -1,0 +1,32 @@
+import { defineFactory } from 'test-fixture-factory'
+
+import type { SlackUser, SlackUserId, SlackWorkspaceId } from '#src/database.ts'
+
+const slackUserFactory = defineFactory<
+  Record<string, unknown>, // no deps
+  void, // no attributes
+  SlackUser // returns a slackUser instance
+>(() => {
+  const slackUser: SlackUser = {
+    slackUserId: 'MOCK_SLACK_USER_ID' as SlackUserId,
+    slackWorkspaceId: 'MOCK_SLACK_WORKSPACE_ID' as SlackWorkspaceId,
+    roughUserId: 'MOCK_ROUGH_USER_ID',
+    roughWorkspaceId: 'MOCK_ROUGH_WORKSPACE_ID',
+    slackWorkspaceUrl: 'https://test.slack.com/team/',
+    roughWorkspacePublicId: 'MOCK_ROUGH_WORKSPACE_PUBLIC_ID',
+    name: 'MOCK_NAME',
+    accessToken: 'xxx.access.token',
+    accessTokenExpiresAt: Date.now() + 1000 * 60 * 30,
+    refreshToken: 'xxx.refresh.token',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  }
+
+  return {
+    value: slackUser,
+  }
+})
+
+const mockSlackUser = slackUserFactory.useValueFn
+
+export { mockSlackUser }

--- a/src/test/use-db.ts
+++ b/src/test/use-db.ts
@@ -16,7 +16,7 @@ const getInMemoryDb = memoize(async () => {
 const dbFactory = defineFactory<
   Record<string, unknown>, // no deps
   void, // no attributes
-  KyselyDb // returns adb instance
+  KyselyDb // returns a db instance
 >(
   async (
     // biome-ignore lint/correctness/noEmptyPattern: vitest requires {}


### PR DESCRIPTION
This commit introduces a comprehensive suite of tests for the Slack user deletion, retrieval, and updating functionalities to ensure robust behavior and reliability.

- Created `delete-slack-user.test.ts` to test the deletion process, covering cases for when a user exists and does not exist.
- Created `get-slack-user.test.ts` for retrieving users, confirming behavior when users are present or absent.
- Created `update-slack-user.test.ts` to validate the updating of user fields and ensure timestamp correctness.
- Introduced `get-or-refresh-access-token.test.ts` to ensure functionality for token management, including tests for expiration logic and user deletion upon token refresh failure.
- Updated `delete-slack-user.ts` to return the number of deleted rows for better feedback.
- Created mock implementations for DB and OAuth to streamline testing and avoid side effects.

These tests are structured to ensure our code handles both expected and edge cases effectively.